### PR TITLE
Handle Invalid Note Title Characters In Event Summary

### DIFF
--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -123,7 +123,8 @@ export const createNoteFromEvent = async (event: GoogleEvent, folderName?:string
             folderPath = folderName;
         }
     }
-    const filePath = normalizePath(`${folderPath}/${event.summary}.md`);
+    let cleanEventSummary = event.summary.replace('/', '-').replace(':', '-').replace('\\', '-');
+    const filePath = normalizePath(`${folderPath}/${cleanEventSummary}.md`);
 
     //check if file already exists
     if(await adapter.exists(filePath)){


### PR DESCRIPTION
If a Calendar event has a summary that includes invalid Note Title characters for Obsidian, when the Note is created from the Calendar event, an error is shown:

```
Uncaught (in promise) Error: File name cannot contain any of the following characters: \ / :
```

This proposed change replaces these invalid characters with dashes ('-'), which are valid characters for Obsidian Note Titles.

To replicate/test - Create a Google Calendar event with a title/summary like `Rob / Joe 1:1`.   Try to Create an Event Note from this event.  It will fail, with the error message shown above in the Developer Console.   With this fix in place, this should no longer happen.