### PR TITLE
Add even more formatting options for `AutoEventNoteCreator`

### DIFF
--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -115,8 +115,26 @@ export const createNoteFromEvent = async (event: GoogleEvent, folderName?: strin
         //check description for {{date}} string replace it with today's date
         folderName = folderName.replace("{{date}}", window.moment().format("YYYY-MM-DD"));
 
+        //check description for {{date-year}} string replace it with the current year.
+        folderName = folderName.replace("{{date-year}}", window.moment().format("YYYY"));
+
+        //check description for {{date-month}} string replace it with the current month.
+        folderName = folderName.replace("{{date-month}}", window.moment().format("MM"));
+
+        //check description for {{date-day}} string replace it with the current numeric day.
+        folderName = folderName.replace("{{date-day}}", window.moment().format(""));
+
         //check description for {{event-date}} string replace with event start date
         folderName = folderName.replace("{{event-date}}", window.moment(event.start.date ?? event.start.dateTime).format("YYYY-MM-DD"));
+
+        //check description for {{event-year}} string replace with event start date's year.
+        folderName = folderName.replace("{{event-year}}", window.moment(event.start.date ?? event.start.dateTime).format("YYYY"));
+
+        //check description for {{event-month}} string replace with event start date's month.
+        folderName = folderName.replace("{{event-month}}", window.moment(event.start.date ?? event.start.dateTime).format("MM"));
+
+        //check description for {{event-day}} string replace with event start date's numeric day.
+        folderName = folderName.replace("{{event-day}}", window.moment(event.start.date ?? event.start.dateTime).format("DD"));
 
         //check description for {{event-title}} string replace with event title
         folderName = folderName.replace("{{event-title}}", event.summary ?? "event-title");

--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -122,7 +122,7 @@ export const createNoteFromEvent = async (event: GoogleEvent, folderName?: strin
         folderName = folderName.replace("{{date-month}}", window.moment().format("MM"));
 
         //check description for {{date-day}} string replace it with the current numeric day.
-        folderName = folderName.replace("{{date-day}}", window.moment().format(""));
+        folderName = folderName.replace("{{date-day}}", window.moment().format("DD"));
 
         //check description for {{event-date}} string replace with event start date
         folderName = folderName.replace("{{event-date}}", window.moment(event.start.date ?? event.start.dateTime).format("YYYY-MM-DD"));


### PR DESCRIPTION
This adds a number of additional options for those with deeply nested hierarchies. It now can auto-complete:

- `date-day`
- `date-month`
- `date-year`
- `event-day`
- `event-month`
- `event-year`