### PR TITLE
Update AutoEventNoteCreator.ts

### DIFF
--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -47,7 +47,7 @@ export const checkForEventNotes = async (plugin: GoogleCalendarPlugin): Promise<
             await createNoteFromEvent(events[i], plugin.settings.defaultFolder, plugin.settings.defaultTemplate, true)
         } else {
 
-            const regex = new RegExp(`:([^:]*-)?${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
+            const regex = new RegExp(`:([^:]*)?-${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
 
             //regex will check for text and extract a template name if it exists
             const match = events[i].description?.match(regex) ?? [];


### PR DESCRIPTION
Fixes an error where a trailing "-" is added as part of the first match, instead of outside of the match, rendering the custom folder structure incorrect and preventing the imported events from moving out of the base folder