### PR TITLE
Let user open note directly when clicking on event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "google-calendar",
-	"version": "1.10.13",
+	"version": "1.10.14",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "google-calendar",
-			"version": "1.10.13",
+			"version": "1.10.14",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@typescript-eslint/eslint-plugin": "^4.25.0",
 				"@typescript-eslint/parser": "^4.25.0",
 				"builtin-modules": "^3.2.0",
-				"esbuild": "^0.12.26",
+				"esbuild": "^0.12.29",
 				"esbuild-svelte": "^0.5.4",
 				"eslint": "^7.27.0",
 				"obsidian": "latest",
@@ -830,9 +830,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.12.26",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.26.tgz",
-			"integrity": "sha512-YmTkhPKjvTJ+G5e96NyhGf69bP+hzO0DscqaVJTi5GM34uaD4Ecj7omu5lJO+NrxCUBRhy2chONLK1h/2LwoXA==",
+			"version": "0.12.29",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+			"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -3002,9 +3002,9 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.12.26",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.26.tgz",
-			"integrity": "sha512-YmTkhPKjvTJ+G5e96NyhGf69bP+hzO0DscqaVJTi5GM34uaD4Ecj7omu5lJO+NrxCUBRhy2chONLK1h/2LwoXA==",
+			"version": "0.12.29",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+			"integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
 			"dev": true
 		},
 		"esbuild-svelte": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-calendar",
-	"version": "1.10.14",
+	"version": "1.10.15",
 	"description": "Interact with your Google Calendar from Inside Obsidian",
 	"main": "main.js",
 	"scripts": {
@@ -19,7 +19,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.25.0",
 		"@typescript-eslint/parser": "^4.25.0",
 		"builtin-modules": "^3.2.0",
-		"esbuild": "^0.12.26",
+		"esbuild": "^0.12.29",
 		"esbuild-svelte": "^0.5.4",
 		"eslint": "^7.27.0",
 		"obsidian": "latest",

--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -277,7 +277,10 @@ export const createNoteFromEvent = async (event: GoogleEvent, folderName?: strin
         file = await vault.create(filePath, '');
         createNotice(`EventNote ${event.summary} created.`)
     } catch (err) {
-        return null
+        if (err.code !== 'ENOENT') {
+            createNotice(err);
+            return;
+        }
     }
 
     //check if the template plugin is active and a template name is given

--- a/src/helper/Helper.ts
+++ b/src/helper/Helper.ts
@@ -94,15 +94,16 @@ export function nearestMinutes(interval: number, someMoment: moment.Moment): mom
 export const sanitizeFileName = (name: string): string => {
     if(!name) return "";
 	return name.trim()
-		.replace('<', 'lt')
-		.replace('>', 'gt')
-		.replace('"', '\'\'')
-		.replace('\\', '-')
-		.replace('/', '-')
-		.replace(':', '-')
-		.replace('|', '-')
-		.replace('*', '')
-		.replace('?', '');
+		.replaceAll('<', 'lt')
+		.replaceAll('>', 'gt')
+		.replaceAll('"', '\'\'')
+		.replaceAll('\\', '-')
+		.replaceAll('/', '-')
+		.replaceAll(':', '-')
+		.replaceAll('|', '-')
+		.replaceAll('*', '')
+		.replaceAll('?', '')
+		.trim()
 }
 
 const findEventNoteForAllFiles = (event: GoogleEvent): EventNoteQueryResult => {

--- a/src/helper/Helper.ts
+++ b/src/helper/Helper.ts
@@ -92,6 +92,7 @@ export function nearestMinutes(interval: number, someMoment: moment.Moment): mom
 
 
 export const sanitizeFileName = (name: string): string => {
+	const invalid_regex = /((?![\u{23}-\u1F6F3]([^\u{FE0F}]|$))\p{Emoji}(?:(?!\u{200D})\p{EComp}|(?=\u{200D})\u{200D}\p{Emoji})*)/ug
     if(!name) return "";
 	return name.trim()
 		.replaceAll('<', 'lt')
@@ -103,6 +104,7 @@ export const sanitizeFileName = (name: string): string => {
 		.replaceAll('|', '-')
 		.replaceAll('*', '')
 		.replaceAll('?', '')
+		.replace(invalid_regex, "-")
 		.trim()
 }
 

--- a/src/helper/types.ts
+++ b/src/helper/types.ts
@@ -49,6 +49,7 @@ export interface GoogleCalendarPluginSettings {
     refreshInterval: number;
     atAnnotationEnabled: boolean;
     debugMode: boolean;
+	openNoteOnClick: boolean;
 
 	viewSettings: { [type in string]: CodeBlockOptions };
     }

--- a/src/svelte/views/EventDetails.svelte
+++ b/src/svelte/views/EventDetails.svelte
@@ -266,7 +266,7 @@
         if(!checkIfEndDateIsValid()) {
             return;
         }
-        if (plugin.settings.useDefaultTemplate && plugin.settings.defaultFolder && plugin.settings.defaultFolder) {
+        if (plugin.settings.useDefaultTemplate && plugin.settings.defaultFolder) {
             createNoteFromEvent(event, plugin.settings.defaultFolder, plugin.settings.defaultTemplate)
         } else {
             new CreateNotePromptModal(event, (newNote:TFile) => eventNoteQueryResult.file = newNote).open();

--- a/src/svelte/views/TimeLineView.svelte
+++ b/src/svelte/views/TimeLineView.svelte
@@ -101,7 +101,7 @@
 			: startDate;
 
 		if (currentDateInterval) clearInterval(currentDateInterval)
-		interval = setInterval(() => updateDate(), 5000);
+		currentDateInterval = setInterval(() => updateDate(), 5000);
 		updateDate();
 
 		if (interval) clearInterval(interval);

--- a/src/svelte/views/TimeLineView.svelte
+++ b/src/svelte/views/TimeLineView.svelte
@@ -18,6 +18,7 @@
 
 	import { findEventNote } from "../../helper/Helper";
 	import { createNoteFromEvent } from "src/helper/AutoEventNoteCreator";
+    import moment, { Moment } from 'moment';
 
 	export let codeBlockOptions: CodeBlockOptions;
 	export let isObsidianView = false;
@@ -31,6 +32,7 @@
 	let loading = false;
 	let events: GoogleEvent[] = [];
 	let interval;
+	let currentDateInterval;
 	let plugin = GoogleCalendarPlugin.getInstance();
 
 	const getEvents = async (date: moment.Moment) => {
@@ -78,6 +80,16 @@
 		}
 	};
 
+	const updateDate = () => {
+		let currentDate: moment.Moment = moment()
+		if (currentDate.hour() === 0 && currentDate.minute() === 0 && startDate.dayOfYear() !== currentDate.dayOfYear()) {
+			startDate = currentDate;
+			date = codeBlockOptions.navigation
+				? startDate.clone().local().add(dateOffset, 'days')
+				: startDate;
+		}
+	}
+
 	$: {
 		startDate = codeBlockOptions.date
 			? window
@@ -87,6 +99,10 @@
 		date = codeBlockOptions.navigation
 			? startDate.clone().local().add(dateOffset, 'days')
 			: startDate;
+
+		if (currentDateInterval) clearInterval(currentDateInterval)
+		interval = setInterval(() => updateDate(), 5000);
+		updateDate();
 
 		if (interval) clearInterval(interval);
 		interval = setInterval(() => refreshData(date), 5000);
@@ -105,6 +121,7 @@
 
 	onDestroy(() => {
 		clearInterval(interval);
+		clearInterval(currentDateInterval);
 	});
 </script>
 

--- a/src/svelte/views/TimeLineView.svelte
+++ b/src/svelte/views/TimeLineView.svelte
@@ -16,6 +16,9 @@
 	import GoogleCalendarPlugin from '../../GoogleCalendarPlugin';
 	import { VIEW_TYPE_GOOGLE_CALENDAR_EVENT_DETAILS } from '../../view/EventDetailsView';
 
+	import { findEventNote } from "../../helper/Helper";
+	import { createNoteFromEvent } from "src/helper/AutoEventNoteCreator";
+
 	export let codeBlockOptions: CodeBlockOptions;
 	export let isObsidianView = false;
 	export let showSettings = false;
@@ -62,10 +65,16 @@
 				refreshData(date);
 			})
 		} else {
-			new EventDetailsModal(event, () => {
-				googleClearCachedEvents();
-				refreshData(date);
-			}).open();
+			if (plugin.settings.openNoteOnClick) {
+				let eventNoteQueryResult = findEventNote(event, plugin);
+				createNoteFromEvent(event, plugin.settings.defaultFolder, plugin.settings.defaultTemplate)
+				app.workspace.getLeaf(true).openFile(eventNoteQueryResult.file);
+			} else {
+				new EventDetailsModal(event, () => {
+					googleClearCachedEvents();
+					refreshData(date);
+				}).open();
+			}
 		}
 	};
 

--- a/src/svelte/views/TimeLineView.svelte
+++ b/src/svelte/views/TimeLineView.svelte
@@ -65,7 +65,7 @@
 				refreshData(date);
 			})
 		} else {
-			if (plugin.settings.openNoteOnClick) {
+			if (plugin.settings.openNoteOnClick && plugin.settings.useDefaultTemplate && plugin.settings.defaultFolder) {
 				let eventNoteQueryResult = findEventNote(event, plugin);
 				createNoteFromEvent(event, plugin.settings.defaultFolder, plugin.settings.defaultTemplate)
 				app.workspace.getLeaf(true).openFile(eventNoteQueryResult.file);

--- a/src/view/GoogleCalendarSettingTab.ts
+++ b/src/view/GoogleCalendarSettingTab.ts
@@ -401,6 +401,20 @@ export class GoogleCalendarSettingTab extends PluginSettingTab {
 					// @ts-ignore
 					cb.containerEl.addClass("templater_search");
 				});
+
+			new Setting(containerEl)
+				.setName("Open Note on Event Click")
+				.setDesc("Open the note when clicking on an event from a calendar view, instead of opening the Event Details modal")
+				.setClass("SubSettings")
+				.addToggle(toggle => {
+					toggle.setValue(this.plugin.settings.openNoteOnClick);
+					toggle.onChange(async (state) => {
+					this.plugin.settings.openNoteOnClick = state;
+					await this.plugin.saveSettings();
+					this.hide();
+					this.display();
+				});
+				})
 		}
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 		"paths": {
 			"src": ["src/*"]
 		},
-		"lib": ["dom", "es5", "scripthost", "es2015"]
+		"lib": ["dom", "es5", "scripthost", "es2015", "ES2021.String"]
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["node_modules/*"]


### PR DESCRIPTION
Give the user an option to open (and create) the note file directly when clicking on an event from the calendar view.

This feature is only available if the user has the `useDefaultTemplate` setting enabled, so that a note can be created in the background without manual user action upon clicking the event on the calendar.

For my personal use case, I want to use Obsidian to manage my meeting notes, but would rather do my event scheduling, etc. in Google Calendar directly, so I don't want to be taken to the meeting details modal when I click on the event. This saves me a few clicks every time I want to access a meeting note from the Calendar.