### PR TITLE
Fix of automatic calendar note imports

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "google-calendar",
 	"name": "Google Calendar",
-	"version": "1.10.14",
+	"version": "1.10.15",
 	"minAppVersion": "0.12.0",
 	"description": "Interact with your Google Calendar from Inside Obsidian",
 	"author": "YukiGasai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "google-calendar",
-	"version": "1.10.13",
+	"version": "1.10.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "google-calendar",
-			"version": "1.10.13",
+			"version": "1.10.15",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "google-calendar",
-	"version": "1.10.14",
+	"version": "1.10.15",
 	"description": "Interact with your Google Calendar from Inside Obsidian",
 	"main": "main.js",
 	"scripts": {

--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -48,14 +48,14 @@ export const checkForEventNotes = async (plugin: GoogleCalendarPlugin): Promise<
         if (plugin.settings.autoCreateEventNotesMarker === "") {
             await createNoteFromEvent(events[i], plugin.settings.defaultFolder, plugin.settings.defaultTemplate, true)
         } else {
-
-            const regex = new RegExp(`:([^:]*-)?${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
+            const regex = new RegExp(`:([^:]*)?-?${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
 
             //regex will check for text and extract a template name if it exists
             const match = events[i].description?.match(regex) ?? [];
             if (match.length == 3) {
                 //the trigger text was found and a new note will be created
-                await createNoteFromEvent(events[i], match[1], match[2], true)
+                //the fallback allows for formats :folder-marker-template:, :marker-template:, :folder-marker:, :marker:
+                await createNoteFromEvent(events[i], match[1] ?? plugin.settings.defaultFolder, match[2] ?? plugin.settings.defaultTemplate, true)
             }
         }
     }

--- a/src/helper/AutoEventNoteCreator.ts
+++ b/src/helper/AutoEventNoteCreator.ts
@@ -48,7 +48,8 @@ export const checkForEventNotes = async (plugin: GoogleCalendarPlugin): Promise<
         if (plugin.settings.autoCreateEventNotesMarker === "") {
             await createNoteFromEvent(events[i], plugin.settings.defaultFolder, plugin.settings.defaultTemplate, true)
         } else {
-            const regex = new RegExp(`:([^:]*)?-?${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
+
+            const regex = new RegExp(`:([^:]*-)?${plugin.settings.autoCreateEventNotesMarker}-?([^:]*)?:`)
 
             //regex will check for text and extract a template name if it exists
             const match = events[i].description?.match(regex) ?? [];


### PR DESCRIPTION
# The problem

The plugin is unable to create the notes following the template and folder set in settings under `Default template` and `Default folder` whenever the `Auto create Event Notes Marker` is set to any non-empty value and the description does not contain full, 3-part `:directory-marker-template` notation. Instead, depending on what's provided it creates a note in root directory or/and without using template.

# Example
## Calendar setup
I've prepared four events in my calendar:
| Name                     | Description                   |
|--------------------------|-------------------------------|
| Nothing                  | :obsidian:                    |
| Only directory    | :directory-obsidian:          |
| Only template            | :obsidian-template:           |
| Directory and location   | :directory-obsidian-template: |

![image](https://github.com/user-attachments/assets/7ad50704-8c1b-4f42-bc3c-82e947115f2d)


## Obisidian setup
Empty vault with `Templates`, `Templater` and `Google Calendar` plugins installed.
![image](https://github.com/user-attachments/assets/a9bad4f4-5555-4376-ade2-df0c97ec47bc)


## Plugin setup
```json
{
  "autoCreateEventKeepOpen": true,
  "importStartOffset": 1,
  "importEndOffset": 1,
  "optionalNotePrefix": "",
  "eventNoteNameFormat": "{{prefix}}{{event-title}}",
  "autoCreateEventNotes": true,
  "autoCreateEventNotesMarker": "obsidian",
  "useDefaultTemplate": true,
  "defaultTemplate": "templates/default.md",
  "defaultFolder": "events"
}
```

## Expected result
- "Nothing" is imported to the `events` directory using `default.md` template.
- "Only directory" is imported to the `directory` directory using `default.md` template.
- "Only template" is imported to the `events` directory using `template.md` template.
- "Directory and location" is imported to the `directory` directory using `template.md` template.

Expectations were set by [documentation of Auto create EventNotes](https://yukigasai.github.io/obsidian-google-calendar/EventNotes/AutoImport)

## Actual result
- 🔴  "Nothing" is imported to the `root` directory without using template. 
- 🔴  "Only directory" is imported to the `directory` directory without using template.
- 🔴  "Only template" is imported to the `root` directory using `template.md` template.
- ✅ "Directory and location" is imported to the `directory` directory using `template.md` template.

![image](https://github.com/user-attachments/assets/d951e778-3014-4c78-85bb-795709aef96d)

# The cause
Whenever the regex `:([^:]*-)?obsidian-?([^:]*)?:` matches a string that does not contains anything that can be put into first or second capturing group the value passed to the `createNoteFromEvent` is set to `undefined`.

| Value | match[1] | match[2] |
| --- | --- | --- |
| :folder-marker-template: | folder | template |
| :marker-template: | undefined| template |
| :folder-template: | folder | undefined |
| :marker: | undefined| undefined |

When undefined is passed to the `createNoteFromEvent` weird things happen - the note does not know what template to use or where it belongs. All other 6 calls to the `createNoteFromEvent` in project use syntax that uses values from config like `createNoteFromEvent(event, this.settings.defaultFolder, this.settings.defaultTemplate)` or very close to this notation.

# The solution
Fallback values from settings should be used whenever the parsed value is undefined.

```js
await createNoteFromEvent(events[i], match[1] ?? plugin.settings.defaultFolder, match[2] ?? plugin.settings.defaultTemplate, true)
```

# The proof
Given exactly the same setup test yielded:

- ✅ "Nothing" is imported to the `events` directory using `default.md` template.
- ✅ "Only directory" is imported to the `directory` directory using `default.md` template.
- ✅ "Only template" is imported to the `events` directory using `template.md` template.
- ✅ "Directory and location" is imported to the `directory` directory using `template.md` template.

![image](https://github.com/user-attachments/assets/58f5d104-76cd-4f0f-a0d3-061dc2900ed0)