### PR TITLE
Replace all instances of invalid characters in filenames

### DIFF
--- a/src/helper/Helper.ts
+++ b/src/helper/Helper.ts
@@ -94,15 +94,15 @@ export function nearestMinutes(interval: number, someMoment: moment.Moment): mom
 export const sanitizeFileName = (name: string): string => {
     if(!name) return "";
 	return name.trim()
-		.replace('<', 'lt')
-		.replace('>', 'gt')
-		.replace('"', '\'\'')
-		.replace('\\', '-')
-		.replace('/', '-')
-		.replace(':', '-')
-		.replace('|', '-')
-		.replace('*', '')
-		.replace('?', '');
+		.replaceAll('<', 'lt')
+		.replaceAll('>', 'gt')
+		.replaceAll('"', '\'\'')
+		.replaceAll('\\', '-')
+		.replaceAll('/', '-')
+		.replaceAll(':', '-')
+		.replaceAll('|', '-')
+		.replaceAll('*', '')
+		.replaceAll('?', '');
 }
 
 const findEventNoteForAllFiles = (event: GoogleEvent): EventNoteQueryResult => {


### PR DESCRIPTION
The current `sanitizeFileName` method utilizes `.replace()` with String patterns. This will only replace the first instance of these disallowed characters, meaning if the an event title has `//` or other multiples of disallowed characters, EventNote creation will fail silently.

This fix uses `.replaceAll()` to swap all instances of disallowed characters with their appropriate replacements.