### PR TITLE
add timelineheight and timelinewidth to the config, formatting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Manage your Google Calendar from inside Obsidian.
 
+⚠️ **This plugin is in stale mode and could stop working at any time. I no longer have/had time to maintain it (for now).**
+
 ## Features
 
 - List Events
@@ -26,9 +28,3 @@ This documentation is also available in the documents folder inside this reposit
 [Hotkeys for templates](https://github.com/Vinzent03/obsidian-hotkeys-for-templates)
 
 [obsidian-periodic-notes](https://github.com/liamcain/obsidian-periodic-notes)
-
-## Sponsor
-
-If you like the plugin maybe 👉👈
-
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/Q5Q1G07N2)

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,10 @@
 {
 	"id": "google-calendar",
 	"name": "Google Calendar",
-	"version": "1.10.15",
+	"version": "1.10.16",
 	"minAppVersion": "0.12.0",
 	"description": "Interact with your Google Calendar from Inside Obsidian",
 	"author": "YukiGasai",
 	"authorUrl": "https://github.com/YukiGasai",
-	"isDesktopOnly": false,
-	"fundingUrl": "https://ko-fi.com/YukiGasai"
+	"isDesktopOnly": false
 }

--- a/src/helper/types.ts
+++ b/src/helper/types.ts
@@ -45,6 +45,10 @@ export interface GoogleCalendarPluginSettings {
     timelineHourFormat: number;
     usDateFormat: boolean;
 
+    // Timeline settings
+    timelineHeight: number;
+    timelineWidth: number;
+
     // General settings
     refreshInterval: number;
     atAnnotationEnabled: boolean;

--- a/src/svelte/components/TimeLine.svelte
+++ b/src/svelte/components/TimeLine.svelte
@@ -1,182 +1,187 @@
 <script lang="ts">
-	import timerStore from '../extra/timerStore';
-	import type { GoogleEvent, Location } from '../../helper/types';
-	import TreeMap from 'ts-treemap';
-	import {
-		dateToPercent,
-		getStartHeightOfHour,
-		getEndHeightOfHour,
-		getStartFromEventHeight,
-		nearestMinutes,
-	} from '../../helper/Helper';
-	import { getEventStartPosition, getEventHeight } from '../../helper/Helper';
-	import GoogleCalendarPlugin from '../../GoogleCalendarPlugin';
-	import EventBox from './EventBox.svelte';
+  import TreeMap from "ts-treemap";
+  import GoogleCalendarPlugin from "../../GoogleCalendarPlugin";
+  import {
+    dateToPercent,
+    getEndHeightOfHour,
+    getEventHeight,
+    getEventStartPosition,
+    getStartFromEventHeight,
+    getStartHeightOfHour,
+    nearestMinutes,
+  } from "../../helper/Helper";
+  import type { GoogleEvent, Location } from "../../helper/types";
+  import timerStore from "../extra/timerStore";
+  import EventBox from "./EventBox.svelte";
 
-	export let height = 700;
-	export let width = 300;
-	export let events: GoogleEvent[];
-	export let day;
-	export let hourRange;
-	export let goToEvent;
-	let locations: Location[] = [];
-	let realWidth = 0;
+  // New reactive statement
+  const plugin = GoogleCalendarPlugin.getInstance();
 
-	const getRedTimeLinePosition = (time) => {
-		const dayPercentage = dateToPercent(time);
-		return Math.floor(height * dayPercentage);
-	};
+  export let events: GoogleEvent[];
+  export let day;
+  export let hourRange;
+  export let goToEvent;
+  let locations: Location[] = [];
+  let realWidth = 0;
 
-	const plugin = GoogleCalendarPlugin.getInstance();
-	let hourFormat = plugin.settings.timelineHourFormat;
-	const currentTime = timerStore();
+  const getRedTimeLinePosition = (time) => {
+    const dayPercentage = dateToPercent(time);
+    return Math.floor(height * dayPercentage);
+  };
 
-	const getLocationArray = (events) => {
-		let eventLocations: Location[] = [];
-		const startMap = new TreeMap<string, GoogleEvent[]>();
-		events.forEach((event) => {
-			const start = event.start.date || event.start.dateTime;
-			if (startMap.has(start)) {
-				startMap.get(start).push(event);
-			} else {
-				startMap.set(start, [event]);
-			}
-		});
+  export let height = plugin.settings.timelineHeight;
+  export let width = plugin.settings.timelineWidth;
 
-		let indentAmount = 0;
-		let latestEndDate = null;
+  let hourFormat = plugin.settings.timelineHourFormat;
+  const currentTime = timerStore();
 
-		for (let events of startMap.values()) {
-			if (events[0].start.dateTime) {
-				const startDate = window.moment(events[0].start.dateTime);
+  const getLocationArray = (events) => {
+    let eventLocations: Location[] = [];
+    const startMap = new TreeMap<string, GoogleEvent[]>();
+    events.forEach((event) => {
+      const start = event.start.date || event.start.dateTime;
+      if (startMap.has(start)) {
+        startMap.get(start).push(event);
+      } else {
+        startMap.set(start, [event]);
+      }
+    });
 
-				if (latestEndDate && startDate.isBefore(latestEndDate, 'minutes')) {
-					indentAmount++;
-				} else {
-					indentAmount = 0;
-				}
+    let indentAmount = 0;
+    let latestEndDate = null;
 
-				latestEndDate = window.moment(events[0].end.dateTime);
-			}
-			events.forEach((event, i) => {
-				const indent = indentAmount * 5;
+    for (let events of startMap.values()) {
+      if (events[0].start.dateTime) {
+        const startDate = window.moment(events[0].start.dateTime);
 
-				const elementWidth = (100 - indent) / events.length;
-				eventLocations = [
-					...eventLocations,
-					{
-						event: event,
-						x: indent + elementWidth * i,
-						y: getEventStartPosition(event, height),
-						width: elementWidth,
-						height: getEventHeight(event, height),
-						fullDay: event.start.date != undefined,
-					},
-				];
-			});
-		}
-		return eventLocations;
-	};
+        if (latestEndDate && startDate.isBefore(latestEndDate, "minutes")) {
+          indentAmount++;
+        } else {
+          indentAmount = 0;
+        }
 
-	let openCreateEventDialog = (e:MouseEvent) => {
-		let y = e.clientY - timeline.getBoundingClientRect().top;
-		const {start, end} = getStartFromEventHeight(height, y, y + 10, new Date(day));
-		const startMoment = nearestMinutes(15, window.moment(start)); 
-		const newEvent:GoogleEvent = {
-			start: {
-				dateTime: startMoment.format()
-			},
-			end: {
-				dateTime: startMoment.clone().add(1, "hour").format()
-			},
-		}
-		goToEvent(newEvent, e)
-	}
+        latestEndDate = window.moment(events[0].end.dateTime);
+      }
+      events.forEach((event, i) => {
+        const indent = indentAmount * 5;
 
-	let timeline: HTMLDivElement;
-	$: if (events) {
-		locations = getLocationArray(events);
-		if(timeline){
-		timeline.parentElement.style.overflow = "hidden"
-		}
-	}
+        const elementWidth = (100 - indent) / events.length;
+        eventLocations = [
+          ...eventLocations,
+          {
+            event: event,
+            x: indent + elementWidth * i,
+            y: getEventStartPosition(event, height),
+            width: elementWidth,
+            height: getEventHeight(event, height),
+            fullDay: event.start.date != undefined,
+          },
+        ];
+      });
+    }
+    return eventLocations;
+  };
+
+  let openCreateEventDialog = (e: MouseEvent) => {
+    let y = e.clientY - timeline.getBoundingClientRect().top;
+    const { start, end } = getStartFromEventHeight(
+      height,
+      y,
+      y + 10,
+      new Date(day),
+    );
+    const startMoment = nearestMinutes(15, window.moment(start));
+    const newEvent: GoogleEvent = {
+      start: {
+        dateTime: startMoment.format(),
+      },
+      end: {
+        dateTime: startMoment.clone().add(1, "hour").format(),
+      },
+    };
+    goToEvent(newEvent, e);
+  };
+
+  let timeline: HTMLDivElement;
+  $: if (events) {
+    locations = getLocationArray(events);
+    if (timeline) {
+      timeline.parentElement.style.overflow = "hidden";
+    }
+  }
 </script>
 
 <div
-	style:height="{height}px"
-	style:width="{width}px"
-	style:max-width="100%"
-	style:margin=" -{getStartHeightOfHour(height, hourRange[0])}px 0px -{getEndHeightOfHour(
-		height,
-		hourRange[1]
-	)}px 0px"
-	class="gcal-timeline"
-	bind:clientWidth={realWidth}
-	bind:this={timeline}
-	on:dblclick={openCreateEventDialog}
+  style:height="{height}px"
+  style:width="{width}px"
+  style:max-width="100%"
+  style:margin=" -{getStartHeightOfHour(height, hourRange[0])}px 0px -{getEndHeightOfHour(
+    height,
+    hourRange[1],
+  )}px 0px"
+  class="gcal-timeline"
+  bind:clientWidth={realWidth}
+  bind:this={timeline}
+  on:dblclick={openCreateEventDialog}
 >
-	<div class="gcal-timeline-container">
-		<div class="gcal-hour-line-container">
-			{#each { length: 24 } as _, i}
-				<div
-					class={hourFormat > 3
-						? 'gcal-hour-line gcal-hour-line-large'
-						: 'gcal-hour-line'}
-					style:height="{height / 24}px"
-				/>
-			{/each}
-		</div>
-	</div>
+  <div class="gcal-timeline-container">
+    <div class="gcal-hour-line-container">
+      {#each { length: 24 } as _, i}
+        <div
+          class={hourFormat > 3
+            ? "gcal-hour-line gcal-hour-line-large"
+            : "gcal-hour-line"}
+          style:height="{height / 24}px"
+        />
+      {/each}
+    </div>
+  </div>
 
-	{#if window.moment().isSame(day, 'day')}
-		<div
-			class="gcal-time-display"
-			style:top="{getRedTimeLinePosition($currentTime)}px"
-		/>
-	{/if}
+  {#if window.moment().isSame(day, "day")}
+    <div
+      class="gcal-time-display"
+      style:top="{getRedTimeLinePosition($currentTime)}px"
+    />
+  {/if}
 
-	{#each locations as location, i (i)}
-
-	<EventBox 
-		location={location}
-		goToEvent={goToEvent}
-		timelineHeight={height}
-		timelineWidth={realWidth}
-	/>
-
-
-	{/each}
+  {#each locations as location, i (i)}
+    <EventBox
+      {location}
+      {goToEvent}
+      timelineHeight={height}
+      timelineWidth={realWidth}
+    />
+  {/each}
 </div>
 
 <style>
+  .gcal-timeline-container {
+    display: flex;
+    gap: 5px;
+  }
 
-	.gcal-timeline-container {
-		display: flex;
-		gap: 5px;
-	}
+  .gcal-hour-line::after {
+    content: "";
+    position: absolute;
+    width: 100%;
+    border-bottom: 1px solid grey;
+  }
 
-	.gcal-hour-line::after {
-		content: '';
-		position: absolute;
-		width: 100%;
-		border-bottom: 1px solid grey;
-	}
+  .gcal-time-display {
+    position: absolute;
+    width: 95%;
+    height: 3px;
+    background: red;
+    overflow: visible;
+    z-index: 2;
+  }
 
-	.gcal-time-display {
-		position: absolute;
-		width: 95%;
-		height: 3px;
-		background: red;
-		overflow: visible;
-		z-index: 2;
-	}
-
-	.gcal-timeline {
-		position: relative;
-		display: flex;
-		flex-direction: row;
-		padding-top: 5px;
-		flex-shrink: 1000;
-		min-height: 0;
-	}
+  .gcal-timeline {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    padding-top: 5px;
+    flex-shrink: 1000;
+    min-height: 0;
+  }
 </style>

--- a/src/svelte/components/TimeLineHourText.svelte
+++ b/src/svelte/components/TimeLineHourText.svelte
@@ -1,65 +1,71 @@
 <script lang="ts">
-	import { getStartHeightOfHour, getEndHeightOfHour } from "../../helper/Helper";
-    import GoogleCalendarPlugin from "../../GoogleCalendarPlugin";
+  import GoogleCalendarPlugin from "../../GoogleCalendarPlugin";
+  import {
+    getEndHeightOfHour,
+    getStartHeightOfHour,
+  } from "../../helper/Helper";
 
-    const plugin = GoogleCalendarPlugin.getInstance();
-    let hourFormat = plugin.settings.timelineHourFormat;
+  const plugin = GoogleCalendarPlugin.getInstance();
+  let hourFormat = plugin.settings.timelineHourFormat;
 
-    export let height = 700;
-    export let hourRange = [0, 24];
+  export let height = plugin.settings.timelineHeight;
+  export let hourRange = [0, 24];
 
-    const switchHourDisplay = () => {
-        hourFormat += 1;
-        if(hourFormat > 5){
-            hourFormat = 0;
-        }
-        plugin.settings.timelineHourFormat = hourFormat;
-        plugin.saveSettings();
+  const switchHourDisplay = () => {
+    hourFormat += 1;
+    if (hourFormat > 5) {
+      hourFormat = 0;
     }
-    
-    const getHourText = (hour:number, hourFormat:number):string => {
-        const hourMoment = window.moment(`${hour}:00:00`, "H:mm:ss");
-        switch (hourFormat) {
-            case 0:
-                return hourMoment.format("H"); 
-            case 1:
-                return hourMoment.format("HH"); 
-            case 2:
-                return hourMoment.format("h");
-            case 3:
-                return hourMoment.format("hh");   
-            case 4:
-                return hourMoment.format("h A")
-            case 5:
-                return hourMoment.format("hh A")
-        }
+    plugin.settings.timelineHourFormat = hourFormat;
+    plugin.saveSettings();
+  };
+
+  const getHourText = (hour: number, hourFormat: number): string => {
+    const hourMoment = window.moment(`${hour}:00:00`, "H:mm:ss");
+    switch (hourFormat) {
+      case 0:
+        return hourMoment.format("H");
+      case 1:
+        return hourMoment.format("HH");
+      case 2:
+        return hourMoment.format("h");
+      case 3:
+        return hourMoment.format("hh");
+      case 4:
+        return hourMoment.format("h A");
+      case 5:
+        return hourMoment.format("hh A");
     }
+  };
 </script>
 
-<div 
-    class="gcal-hour-text-container"
-    style:margin=" -{getStartHeightOfHour(height, hourRange[0])}px 0px -{getEndHeightOfHour(height, hourRange[1])}px 0px"
+<div
+  class="gcal-hour-text-container"
+  style:margin=" -{getStartHeightOfHour(height, hourRange[0])}px 0px -{getEndHeightOfHour(
+    height,
+    hourRange[1],
+  )}px 0px"
 >
-    {#each {length: 24} as _, i }
-        <span class=gcal-hour-text
-        on:click={switchHourDisplay}
-        on:keypress={switchHourDisplay}
-        style:height="{height/24}px"
-        style:font-size="{height/50}px" 
-        >{getHourText(i,hourFormat)}</span>
-    {/each}
+  {#each { length: 24 } as _, i}
+    <span
+      class="gcal-hour-text"
+      on:click={switchHourDisplay}
+      on:keypress={switchHourDisplay}
+      style:height="{height / 24}px">{getHourText(i, hourFormat)}</span
+    >
+  {/each}
 </div>
 
 <style>
-    .gcal-hour-text-container {
-        display: flex;
-        flex-direction: column;
-        min-height: 0;
-        overflow: hidden;
-    }
+  .gcal-hour-text-container {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
 
-    .gcal-hour-text {
-        font-family: "consolas";
-        display: block;
-    }
+  .gcal-hour-text {
+    font-family: "consolas";
+    display: block;
+  }
 </style>

--- a/src/view/GoogleCalendarSettingTab.ts
+++ b/src/view/GoogleCalendarSettingTab.ts
@@ -1,20 +1,20 @@
-import type { Template } from "../helper/types";
-import GoogleCalendarPlugin from "src/GoogleCalendarPlugin";
-import { createNotice } from "src/helper/NoticeHelper";
 import {
-	PluginSettingTab,
 	App,
-	Setting,
 	Notice,
 	Platform,
+	PluginSettingTab,
+	Setting,
 } from "obsidian";
+import GoogleCalendarPlugin from "src/GoogleCalendarPlugin";
+import { createNotice } from "src/helper/NoticeHelper";
 import { LoginGoogle, StartLoginGoogleMobile } from "../googleApi/GoogleAuth";
-import { getRefreshToken, setAccessToken, setExpirationTime, setRefreshToken } from "../helper/LocalStorage";
 import { listCalendars } from "../googleApi/GoogleListCalendars";
+import { checkForNewWeeklyNotes } from "../helper/DailyNoteHelper";
+import { getRefreshToken, setAccessToken, setExpirationTime, setRefreshToken } from "../helper/LocalStorage";
+import type { Template } from "../helper/types";
+import { OAuthAlertModal } from "../modal/OAuthAlertModal";
 import { FileSuggest } from "../suggest/FileSuggest";
 import { FolderSuggest } from "../suggest/FolderSuggester";
-import { checkForNewWeeklyNotes } from "../helper/DailyNoteHelper";
-import { OAuthAlertModal } from "../modal/OAuthAlertModal";
 
 export class GoogleCalendarSettingTab extends PluginSettingTab {
 	plugin: GoogleCalendarPlugin;
@@ -153,6 +153,37 @@ export class GoogleCalendarSettingTab extends PluginSettingTab {
 				})
 			});
 
+		new Setting(containerEl)
+			.setName("Timeline Height")
+			.setDesc("Set the timeline view height in pixels.")
+			.addText(cb =>
+				cb
+					.setValue(this.plugin.settings.timelineHeight.toString())
+					.onChange(async (value) => {
+						// Convert input string back to number as needed
+						const parsedValue = parseInt(value);
+						if (!isNaN(parsedValue)) {
+							this.plugin.settings.timelineHeight = parsedValue;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("Timeline Width")
+			.setDesc("Set the timeline view width in pixels.")
+			.addText(cb =>
+				cb
+					.setValue(this.plugin.settings.timelineWidth.toString())
+					.onChange(async (value) => {
+						// Convert input string back to number as needed
+						const parsedValue = parseInt(value);
+						if (!isNaN(parsedValue)) {
+							this.plugin.settings.timelineWidth = parsedValue;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
 
 		new Setting(containerEl)
 			.setName("Use event Notification")
@@ -447,7 +478,7 @@ export class GoogleCalendarSettingTab extends PluginSettingTab {
 				})
 			})
 
-		for (const ignorePattern of this.plugin.settings.ignorePatternList ) {
+		for (const ignorePattern of this.plugin.settings.ignorePatternList) {
 			new Setting(containerEl)
 				.setName(ignorePattern)
 				.setClass("SubSettings")


### PR DESCRIPTION
this tries to not adjust gcal-hour-text-container font, as it can get unproductively large. It seems to better to keep it at the same size as the default font, which is 13 px. I believe many people wanted this feature to address the event text not showing up properly due to the 700px limitations. This preverves the default values, but leaves it to the users to update the values in the settings and then put into effect once obsidian has been restarted.
I did not modify the README.md yet, please comment and help me see what needs to change. I did not see a lint config for svelte files. So the formatting I have with my default prettier fomatting seemed off from the existing code format, but it seems to be formatting was not enforced prior.

![image](https://github.com/user-attachments/assets/cd436a44-f445-4f32-b035-001e26a7d3f4)
